### PR TITLE
Use EIP for master nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,3 @@ configured to communicate via TLS using certificates.
 
 The required certificate authorities and certificates are generated using cfssl
 automatically.
-
-## Known issues / limitations
-
-### Kubectl
-
-kubectl is configured to talk to the first master node via IP. If the first
-master node is unavailable, you need to update your kubectl config to talk
-to another master node or bring the master node back up.
-You can of course setup DNS A records for each one of your nodes and use
-a DNS name instead of the IP in your config.

--- a/playbook/ansible.cfg
+++ b/playbook/ansible.cfg
@@ -1,4 +1,4 @@
 [defaults]
 hostfile = /secret/inventory
 host_key_checking = False
-timeout = 15
+timeout = 60

--- a/playbook/ansible.cfg
+++ b/playbook/ansible.cfg
@@ -1,4 +1,4 @@
 [defaults]
-hostfile = ../secret/inventory
+hostfile = /secret/inventory
 host_key_checking = False
 timeout = 15

--- a/playbook/cluster-bootstrap.yml
+++ b/playbook/cluster-bootstrap.yml
@@ -10,6 +10,13 @@
     - infra-master
     - infra-worker
     - infra-inventory
+  tasks:
+    - wait_for:
+        port: 22
+        host: "{{ hostvars[item]['ansible_host'] }}"
+        search_regex: OpenSSH
+        delay: 10
+      with_items: "{{ groups['all'] }}"
 
 # Bootstrap ansible for CoreOS
 - hosts: master_nodes, worker_nodes

--- a/playbook/cluster-bootstrap.yml
+++ b/playbook/cluster-bootstrap.yml
@@ -9,18 +9,13 @@
     - common
     - infra-master
     - infra-worker
+    - infra-inventory
 
 # Bootstrap ansible for CoreOS
 - hosts: master_nodes, worker_nodes
   gather_facts: False
   roles:
     - defunctzombie.coreos-bootstrap
-
-# Write inventory
-- hosts: localhost
-  connection: local
-  roles:
-    - infra-inventory
 
 # Gather facts on all nodes
 - hosts: all

--- a/playbook/group_vars/all
+++ b/playbook/group_vars/all
@@ -1,6 +1,6 @@
 # common variables
 cluster_name: k8s
-cluster_zone: CH-DK-2
+cluster_zone: CH-GVA-2
 ssh_key: "{{ cluster_name }}-key"
 anti_affinity_group_name: "{{ cluster_name }}-aag"
 

--- a/playbook/group_vars/all
+++ b/playbook/group_vars/all
@@ -13,6 +13,9 @@ initial_num_worker_nodes: 3
 worker_security_group_name: "{{ cluster_name }}-worker-sg"
 worker_instance_size: Small
 
+# exoip variables
+exoip_version: "latest"
+
 # kubernetes variables
 k8s_version: "v1.5.1_coreos.0"
 k8s_etcd_version: "2.2.1"

--- a/playbook/roles/addons/tasks/main.yml
+++ b/playbook/roles/addons/tasks/main.yml
@@ -1,10 +1,10 @@
 - debug:
-    msg: Wait up to 10 minutes for our cluster to initialize and come up before we can deploy addons.
+    msg: Wait up to 30 minutes for our cluster to initialize and come up before we can deploy addons.
 
 - wait_for:
     port: 443
-    host: "{{ hostvars[groups['master_nodes'][0]]['ansible_host'] }}"
-    timeout: 600
+    host: "{{ hostvars[groups['master_nodes'][0]]['master_eip'] }}"
+    timeout: 1800
 
 - name: tempfile
   shell: mktemp

--- a/playbook/roles/certificates/tasks/_generate_certificates.yml
+++ b/playbook/roles/certificates/tasks/_generate_certificates.yml
@@ -5,7 +5,7 @@
   with_items: "{{ groups['all'] }}"
 
 - name: create kubernetes apiserver certificates
-  shell: echo '{{ lookup('template', '../templates/ecdsa_csr.j2', convert_data=False) }}' | bin/cfssl gencert -ca=kubernetes/apiserver-ca.pem -ca-key=kubernetes/apiserver-ca-key.pem -config=ca_config.json -profile=server -hostname="127.0.0.1,10.100.0.1,{{ hostvars[item]['ansible_host'] }}" - | bin/cfssljson -bare "kubernetes/{{ item }}/apiserver"
+  shell: echo '{{ lookup('template', '../templates/ecdsa_csr.j2', convert_data=False) }}' | bin/cfssl gencert -ca=kubernetes/apiserver-ca.pem -ca-key=kubernetes/apiserver-ca-key.pem -config=ca_config.json -profile=server -hostname="127.0.0.1,10.100.0.1,{{ hostvars[item]['ansible_host'] }},{{ hostvars[item]['master_eip'] }}" - | bin/cfssljson -bare "kubernetes/{{ item }}/apiserver"
   args:
     chdir: ../secret/ssl
     creates: kubernetes/{{ item }}/apiserver.pem

--- a/playbook/roles/common/tasks/cloudstack_ini.yml
+++ b/playbook/roles/common/tasks/cloudstack_ini.yml
@@ -1,34 +1,37 @@
 - stat:
-    path: ../secret/cloudstack.ini
+    path: /secret/cloudstack.ini
   register: csini
 
-- fail: msg="test"
-  when: "csini.stat.exists and not csini.stat.isreg"
-
 - set_fact:
-    EXO_API_KEY: "{{ lookup('ini', 'key section=cloudstack file=../secret/cloudstack.ini') }}"
+    EXO_API_KEY: "{{ lookup('ini', 'key section=cloudstack file=/secret/cloudstack.ini') }}"
   when: "csini.stat.exists and csini.stat.isreg"
 
 - set_fact:
-    EXO_API_SECRET: "{{ lookup('ini', 'secret section=cloudstack file=../secret/cloudstack.ini') }}"
+    EXO_API_SECRET: "{{ lookup('ini', 'secret section=cloudstack file=/secret/cloudstack.ini') }}"
   when: "csini.stat.exists and csini.stat.isreg"
-
-- set_fact:
-    EXO_API_ENDPOINT: "{{ lookup('env', 'EXO_API_ENDPOINT') | default('https://api.exoscale.ch/compute', true) }}"
-
-- set_fact:
-    EXO_API_KEY: "{{ lookup('env', 'EXO_API_KEY') }}"
-  when: "not EXO_API_KEY"
-
-- set_fact:
-    EXO_API_SECRET: "{{ lookup('env', 'EXO_API_SECRET') }}"
-  when: "not EXO_API_SECRET"
 
 - fail:
     msg: "Please set the EXO_API_KEY and EXO_API_SECRET environment variables. You can find these on your account page. https://portal.exoscale.ch/account/profile/api"
-  when: not EXO_API_KEY and not EXO_API_SECRET
+  when: EXO_API_KEY is not defined and EXO_API_SECRET is not defined and not lookup('env', 'EXO_API_KEY') and not lookup('env', 'EXO_API_SECRET')
+
+- set_fact:
+    EXO_API_KEY: "{{ lookup('env', 'EXO_API_KEY') | default(EXO_API_KEY, true) }}"
+
+- set_fact:
+    EXO_API_SECRET: "{{ lookup('env', 'EXO_API_SECRET') | default(EXO_API_SECRET, true) }}"
+
+- set_fact:
+    EXO_API_ENDPOINT: "{{ lookup('ini', 'endpoint section=cloudstack file=/secret/cloudstack.ini') }}"
+  when: "csini.stat.exists and csini.stat.isreg"
+
+- set_fact:
+    EXO_API_ENDPOINT: 'https://api.exoscale.ch/compute'
+  when: EXO_API_ENDPOINT is not defined
+
+- set_fact:
+    EXO_API_ENDPOINT: "{{ lookup('env', 'EXO_API_ENDPOINT') | default(EXO_API_ENDPOINT, true) }}"
 
 - name: write cloudstack.ini
   template:
     src: cloudstack_ini.j2
-    dest: ../secret/cloudstack.ini
+    dest: /secret/cloudstack.ini

--- a/playbook/roles/common/tasks/create_secgroup_rules.yml
+++ b/playbook/roles/common/tasks/create_secgroup_rules.yml
@@ -12,6 +12,13 @@
      security_group: "{{ master_security_group_name }}"
      start_port: 443
      end_port: 443
+  - name: master to master exoip
+    local_action:
+     module: cs_securitygroup_rule
+     security_group: "{{ master_security_group_name }}"
+     user_security_group: "{{ master_security_group_name }}"
+     start_port: 12345
+     end_port: 12345
   # infra-etcd
   - name: master to master etcd2 client ports
     local_action:

--- a/playbook/roles/infra-inventory/tasks/main.yml
+++ b/playbook/roles/infra-inventory/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - copy:
     src: inventory
-    dest: ../secret/inventory
+    dest: /secret/inventory
   when: inventory_move_required.stat.exists
 
 - file:
@@ -14,4 +14,4 @@
 - name: write inventory file
   template:
     src: inventory.j2
-    dest: ../secret/inventory
+    dest: /secret/inventory

--- a/playbook/roles/infra-inventory/templates/inventory.j2
+++ b/playbook/roles/infra-inventory/templates/inventory.j2
@@ -3,6 +3,9 @@
 {{ name }} ansible_host={{ hostvars[name]['ansible_host'] }}
 {% endfor %}
 
+[master_nodes:vars]
+master_eip={{ master_eip }}
+
 [worker_nodes]
 {% for name in groups['worker_nodes'] %}
 {{ name }} ansible_host={{ hostvars[name]['ansible_host'] }}

--- a/playbook/roles/infra-master/tasks/create_nodes.yml
+++ b/playbook/roles/infra-master/tasks/create_nodes.yml
@@ -19,6 +19,7 @@
   - add_host:
       groups: master_nodes
       hostname: "{{ item.display_name }}"
+      master_eip: "{{ master_eip }}"
       ansible_host: "{{ item.default_ip }}"
       ansible_user: core
       ansible_ssh_private_key_file: "../secret/id_rsa_{{ ssh_key }}"

--- a/playbook/roles/infra-master/tasks/main.yml
+++ b/playbook/roles/infra-master/tasks/main.yml
@@ -1,2 +1,3 @@
 ---
+  - include: register_eip.yml
   - include: create_nodes.yml

--- a/playbook/roles/infra-master/tasks/register_eip.yml
+++ b/playbook/roles/infra-master/tasks/register_eip.yml
@@ -1,0 +1,14 @@
+- name: Register EIP for master nodes
+  local_action:
+    module: cs_ip_address
+    zone: CH-GVA-2
+  register: eip
+  when: "'master_nodes' not in groups or 'master_eip' not in hostvars[groups['master_nodes'][0]]"
+
+- set_fact:
+    master_eip: "{{ hostvars[groups['master_nodes'][0]]['master_eip'] }}"
+  when: "'skipped' in eip and eip['skipped']"
+
+- set_fact:
+    master_eip: "{{ eip.ip_address }}"
+  when: "'ip_address' in eip"

--- a/playbook/roles/kubectl/tasks/main.yml
+++ b/playbook/roles/kubectl/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: kubectl config set-cluster
-  shell: kubectl --kubeconfig=/secret/kubeconfig config set-cluster default-cluster --server=https://"{{ hostvars[groups['master_nodes'][0]]['ansible_host'] }}" --certificate-authority=../secret/ssl/kubernetes/apiserver-ca.pem --embed-certs=true
+  shell: kubectl --kubeconfig=/secret/kubeconfig config set-cluster default-cluster --server=https://"{{ hostvars[groups['master_nodes'][0]]['master_eip'] }}" --certificate-authority=../secret/ssl/kubernetes/apiserver-ca.pem --embed-certs=true
 
 - name: kubectl config set-credentials
   shell: kubectl --kubeconfig=/secret/kubeconfig config set-credentials default-admin --certificate-authority=../secret/ssl/ca.pem --client-key=../secret/ssl/kubernetes/kubectl-key.pem --client-certificate=../secret/ssl/kubernetes/kubectl.pem --embed-certs=true

--- a/playbook/roles/kubernetes-master/tasks/_master_components.yml
+++ b/playbook/roles/kubernetes-master/tasks/_master_components.yml
@@ -1,8 +1,12 @@
 # kubernetes components
 - set_fact:
+    master_eip: "{{ hostvars[groups['master_nodes'][0]]['master_eip'] }}"
     master1_ip: "{{ hostvars[groups['master_nodes'][0]]['ansible_host'] }}"
     master2_ip: "{{ hostvars[groups['master_nodes'][1]]['ansible_host'] }}"
     master3_ip: "{{ hostvars[groups['master_nodes'][2]]['ansible_host'] }}"
+    EXO_API_ENDPOINT: "{{ lookup('ini', 'endpoint section=cloudstack file=/secret/cloudstack.ini') }}"
+    EXO_API_KEY: "{{ lookup('ini', 'key section=cloudstack file=/secret/cloudstack.ini') }}"
+    EXO_API_SECRET: "{{ lookup('ini', 'secret section=cloudstack file=/secret/cloudstack.ini') }}"
 
 - template:
     src: templates/kubelet.service.j2
@@ -15,6 +19,22 @@
 - file:
     path: /etc/kubernetes/manifests
     state: directory
+    mode: 0644
+
+- template:
+    src: templates/eip.network.j2
+    dest: /etc/systemd/network/eip.network
+    owner: root
+    group: root
+    mode: 0644
+
+- command: systemctl restart systemd-networkd
+
+- template:
+    src: templates/exoip.j2
+    dest: /etc/kubernetes/manifests/exoip.yaml
+    owner: root
+    group: root
     mode: 0644
 
 - template:

--- a/playbook/roles/kubernetes-master/templates/eip.network.j2
+++ b/playbook/roles/kubernetes-master/templates/eip.network.j2
@@ -1,0 +1,5 @@
+[Match]
+Name=lo
+
+[Network]
+Address={{ master_eip }}/32

--- a/playbook/roles/kubernetes-master/templates/exoip.j2
+++ b/playbook/roles/kubernetes-master/templates/exoip.j2
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: exoip
+  namespace: kube-system
+  labels:
+    app: exoip
+spec:
+  containers:
+    -
+      name: exoip
+      image: "exoscale/exoip:{{ exoip_version }}"
+      args:
+        - -W
+      ports:
+        -
+          containerPort: 12345
+          hostPort: 12345
+          name: exoip
+      env:
+        - name: IF_ADDRESS
+          value: {{ master_eip }}
+        - name: IF_EXOSCALE_PEER_GROUP
+          value: {{ master_security_group_name }}
+        - name: IF_EXOSCALE_API_ENDPOINT
+          value: {{ EXO_API_ENDPOINT }}
+        - name: IF_EXOSCALE_API_KEY
+          value: {{ EXO_API_KEY }}
+        - name: IF_EXOSCALE_API_SECRET
+          value: {{ EXO_API_SECRET }}
+  hostNetwork: true
+  restartPolicy: Always

--- a/playbook/roles/kubernetes-worker/tasks/_kubernetes_components.yml
+++ b/playbook/roles/kubernetes-worker/tasks/_kubernetes_components.yml
@@ -1,7 +1,5 @@
 - set_fact:
-     master1_ip: "{{ hostvars[groups['master_nodes'][0]]['ansible_host'] }}"
-     master2_ip: "{{ hostvars[groups['master_nodes'][1]]['ansible_host'] }}"
-     master3_ip: "{{ hostvars[groups['master_nodes'][2]]['ansible_host'] }}"
+    master_eip: "{{ hostvars[groups['master_nodes'][0]]['master_eip'] }}"
 
 - file:
     path: /etc/kubernetes/manifests

--- a/playbook/roles/kubernetes-worker/templates/haproxy.cfg.j2
+++ b/playbook/roles/kubernetes-worker/templates/haproxy.cfg.j2
@@ -29,13 +29,3 @@ frontend ft_private_registry
 
 backend bk_private_registry
     server localhost 127.0.0.1:32500 check
-
-# local worker proxy to apiserver on all masters
-frontend ft_kube_apiserver
-    bind 127.0.0.1:8443
-    default_backend bk_kube_apiserver
-
-backend bk_kube_apiserver
-{% for item in groups['master_nodes'] %}
-    server {{ hostvars[item]['ansible_hostname'] }} {{ hostvars[item]['ansible_host'] }}:443 check
-{% endfor %}

--- a/playbook/roles/kubernetes-worker/templates/kube_proxy.j2
+++ b/playbook/roles/kubernetes-worker/templates/kube_proxy.j2
@@ -12,7 +12,7 @@ spec:
       command:
         - /hyperkube
         - proxy
-        - "--master=https://127.0.0.1:8443"
+        - "--master=https://{{ master_eip }}"
         - "--kubeconfig=/etc/kubernetes/kube_config.yaml"
         - "--proxy-mode=iptables"
       image: "quay.io/coreos/hyperkube:{{ k8s_version }}"

--- a/playbook/roles/kubernetes-worker/templates/kubelet.service.j2
+++ b/playbook/roles/kubernetes-worker/templates/kubelet.service.j2
@@ -1,7 +1,7 @@
 [Service]
 Environment=KUBELET_VERSION={{ k8s_version }}
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
-  --api-servers=https://127.0.0.1:8443 # connect through local haproxy \
+  --api-servers=https://{{ master_eip }} \
   --register-node=true \
   --allow-privileged=true \
   --config=/etc/kubernetes/manifests \


### PR DESCRIPTION
By using Exoscale's new Elastic IP feature for the master nodes coupled with automatic failover of the IP we resolve the issue where kubectl was only ever configured to talk to one of the masters. Also we can remove the previous workaround of the worker nodes using a local haproxy that acted as a loadbalancer towards all the masters for the apiserver.

Both kubectl and worker components are now configured to talk to the EIP. The masters are configured to automatically reassociate the EIP in case the current holder becomes unavailable.