### PR TITLE
Docker limit logs

### DIFF
--- a/playbook/roles/infra-master/templates/master_user_data.j2
+++ b/playbook/roles/infra-master/templates/master_user_data.j2
@@ -62,3 +62,8 @@ coreos:
                         [Unit]
                         Requires=flanneld.service
                         After=flanneld.service
+                -
+                    name: 20-docker-opts.conf
+                    content: |
+                        [Service]
+                        Environment="DOCKER_OPTS=--log-opt max-size=50m --log-opt max-file=3"

--- a/playbook/roles/infra-worker/templates/worker_user_data.j2
+++ b/playbook/roles/infra-worker/templates/worker_user_data.j2
@@ -40,3 +40,9 @@ coreos:
                     content: |
                         [Unit]
                         Requires=flanneld.service
+                -
+                    name: 20-docker-opts.conf
+                    content: |
+                        [Service]
+                        Environment="DOCKER_OPTS=--log-opt max-size=50m --log-opt max-file=3"
+


### PR DESCRIPTION
 by default there is no limit for docker container log files.
Could be done by adding DOCKER_OPTS