### PR TITLE
EXOIP Security Rule has to be UDP

### DIFF
--- a/playbook/roles/common/tasks/create_secgroup_rules.yml
+++ b/playbook/roles/common/tasks/create_secgroup_rules.yml
@@ -17,6 +17,7 @@
      module: cs_securitygroup_rule
      security_group: "{{ master_security_group_name }}"
      user_security_group: "{{ master_security_group_name }}"
+     protocol: udp
      start_port: 12345
      end_port: 12345
   # infra-etcd


### PR DESCRIPTION
exoip POD requires a UDP security rule... (former version defaults to TCP)